### PR TITLE
Update util.js

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -55,16 +55,10 @@ export function getMetadata(metaFileContent, additionalGrantList) {
     .map(line => {
       if (!line.startsWith('// ')) return;
       line = line.slice(3).trim();
-      const i = line.search(/\s/);
-      if (i < 0) {
-        if (['@unwrap', '@noframes'].includes(line)) {
-          return [line, ''];
-        } else {
-          return;
-        }
-      }
-      const key = line.slice(0, i);
-      const value = line.slice(i + 1).trim();
+      const matches = line.match(/^(\S+)(\s.*)?$/);
+      if (!matches) return;
+      const key = matches[1];
+      const value = (matches[2] || '').trim();
       if (key === '@grant') {
         grantSet.add(value);
         return;

--- a/src/util.js
+++ b/src/util.js
@@ -55,8 +55,14 @@ export function getMetadata(metaFileContent, additionalGrantList) {
     .map(line => {
       if (!line.startsWith('// ')) return;
       line = line.slice(3).trim();
-      const i = line.indexOf(' ');
-      if (i < 0) return;
+      const i = line.search(/\s/);
+      if (i < 0) {
+        if (['@unwrap', '@noframes'].includes(line)) {
+          return [line, ''];
+        } else {
+          return;
+        }
+      }
       const key = line.slice(0, i);
       const value = line.slice(i + 1).trim();
       if (key === '@grant') {


### PR DESCRIPTION
When using [violentmonkey/generator-userscript](https://github.com/violentmonkey/generator-userscript) I noticed that not all lines from my `meta.js` were carried over to my userscript because:
1. I used tabs instead of spaces
2. I used a key without a value (`@noframes`)

To fix this, I made two small changes to the mapping function of  `const entries`:
1. changed `indexOf(' ')` to `search(/\s/)`, to support tabs
2. added a conditional for no-value keys `@unwrap` and `@noframes`