### PR TITLE
Add Development Container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  build:
+    build:
+      context: "./images/build"
+      network: host
+    cap_drop: ["ALL"]
+    entrypoint: ["pnpm"]
+    network_mode: "host"
+    security_opt: ["no-new-privileges:true"]
+    volumes:
+      # Bind the current directory to the working directory inside the container.
+      - type: "bind"
+        source: "./"
+        target: "/rollup-plugin-userscript"
+    
+    working_dir: "/rollup-plugin-userscript"

--- a/images/build/Dockerfile
+++ b/images/build/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:18.20.3-alpine@sha256:5069da655539e2e986ce3fd1757f24a41b846958566c89ff4a48874434d73749
+
+# Add PNPM.
+RUN npm install -g pnpm@9.1.4

--- a/pnpm
+++ b/pnpm
@@ -1,0 +1,9 @@
+#!/bin/sh
+if command -v podman; then
+    CONTAINER_ENGINE=podman
+else
+    CONTAINER_ENGINE=docker
+fi
+
+$CONTAINER_ENGINE compose build && \
+$CONTAINER_ENGINE compose run --rm --service-ports build "$@"

--- a/pnpm.ps1
+++ b/pnpm.ps1
@@ -1,0 +1,2 @@
+# Run a shell script with the same name as this script using WSL.
+& 'wsl' '--exec' ('./{0}' -f [System.Io.Path]::GetFileNameWithoutExtension($PSCommandPath)) $args


### PR DESCRIPTION
## What are these changes?
Adds Docker/Podman support to this project.

## Why are these changes being made?
A unified development environment improves the first-time developer experience, and makes the project more deterministic. Rather than needing a guide on installing prerequisite dependencies, developers can simply use the included container image and compose configuration to automatically generate a development environment. This also improves error reproduction and troubleshooting.

Simply run `./pnpm` to launch a temporary container and execute PNPM on the project. Works with Podman and rootless Docker.

## Checklist
- [X] `./pnpm install` succeeds.
- [X] `./pnpm run ci` succeeds.
- [X] `./pnpm run lint` succeeds.
- [X] `./pnpm run dev` succeeds.
- [X] `./pnpm run clean` succeeds.
- [X] `./pnpm run build:js` succeeds.
- [X] `./pnpm run build:types` succeeds.
- [X] `./pnpm run build` succeeds.
- [X] `./pnpm run prepare` succeeds.
- [X] `./pnpm run prepublishOnly` succeeds.

----

### Additional notes:
* `git` is not included in the image causing Husky to not install and return a `0` exit code.