### PR TITLE
Add support for `GM.*` and `unsafeWindow` autogranting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'fs/promises';
 import MagicString from 'magic-string';
 import type { Plugin } from 'rollup';
-import { collectGmApi, getMetadata } from './util';
+import { collectGrants, getMetadata } from './util';
 
 const suffix = '?userscript-metadata';
 
@@ -25,7 +25,7 @@ export default (transform?: (metadata: string) => string): Plugin => {
     },
     transform(code, id) {
       const ast = this.parse(code);
-      const grantSetPerFile = collectGmApi(ast);
+      const grantSetPerFile = collectGrants(ast);
       grantMap.set(id, grantSetPerFile);
     },
     /**

--- a/src/util.ts
+++ b/src/util.ts
@@ -19,29 +19,6 @@ export function collectGrants(ast: AstNode) {
         node.type === 'MemberExpression' &&
         isReference(node, parent)
       ) {
-        function getMemberExpressionFullNameRecursive(astNode: MemberExpression): string | null {
-          if (astNode.property.type !== 'Identifier') {
-            return null;
-          }
-
-          switch (astNode.object.type) {
-            case 'MemberExpression': {
-              const nameSoFar = getMemberExpressionFullNameRecursive(astNode.object);
-              if (nameSoFar == null) {
-                return null;
-              }
-
-              return `${nameSoFar}.${astNode.property.name}`
-            }
-            case 'Identifier': {
-              return `${astNode.object.name}.${astNode.property.name}`;
-            }
-            default: {
-              return null;
-            }
-          }
-        }
-
         const fullName = getMemberExpressionFullNameRecursive(node);
         const match = GRANTS_REGEXP.exec(fullName);
         if (match) {
@@ -67,6 +44,29 @@ export function collectGrants(ast: AstNode) {
     },
   });
   return grantSetPerFile;
+}
+
+function getMemberExpressionFullNameRecursive(astNode: MemberExpression): string | null {
+  if (astNode.property.type !== 'Identifier') {
+    return null;
+  }
+
+  switch (astNode.object.type) {
+    case 'MemberExpression': {
+      const nameSoFar = getMemberExpressionFullNameRecursive(astNode.object);
+      if (nameSoFar == null) {
+        return null;
+      }
+
+      return `${nameSoFar}.${astNode.property.name}`
+    }
+    case 'Identifier': {
+      return `${astNode.object.name}.${astNode.property.name}`;
+    }
+    default: {
+      return null;
+    }
+  }
 }
 
 export function getMetadata(

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,7 +6,7 @@ import type { MemberExpression } from 'estree';
 
 const META_START = '// ==UserScript==';
 const META_END = '// ==/UserScript==';
-const GRANTS_REGEXP = /^unsafeWindow|GM[._][a-zA-Z0-9_]+/;
+const GRANTS_REGEXP = /^(unsafeWindow$|GM[._]\w+)/;
 
 export function collectGrants(ast: AstNode) {
   let scope = attachScopes(ast, 'scope');

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -53,6 +53,13 @@ describe('collectGrants', () => {
     expect(result).toContain('unsafeWindow');
   });
 
+  it('should return nothing unsafeWindow when presented with unsafeWindowButNotReally', () => {
+    const astNode = parseCodeAsEstreeAst(`unsafeWindowButNotReally`);
+    const result = collectGrants(astNode);
+
+    expect(result.size).toBe(0);
+  });
+
   it('should return unsafeWindow even when a subfield is accessed', () => {
     const astNode = parseCodeAsEstreeAst(`unsafeWindow.anotherThing`);
     const result = collectGrants(astNode);


### PR DESCRIPTION
- Rename `collectGmApis()` to `collectGrants()`
- Use a regular expression instead of a hard-coded list of GM APIs for future-proofing
- Add a bunch of tests for the new functionality

Fixes #1 and #2